### PR TITLE
Automatically add published-with-gradle-metadata marker to POM

### DIFF
--- a/src/test/java/org/gradlex/maven/gmm/test/GMMMavenPluginTest.java
+++ b/src/test/java/org/gradlex/maven/gmm/test/GMMMavenPluginTest.java
@@ -67,7 +67,6 @@ class GMMMavenPluginTest {
         try {
             writeString(mavenProducerBuild.toPath(), """
                 <project>
-                  <!-- do_not_remove: published-with-gradle-metadata -->
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>org.gradlex</groupId>
                   <artifactId>gradle-module-metadata-maven-plugin-integration-test</artifactId>
@@ -129,6 +128,13 @@ class GMMMavenPluginTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    void marker_comment_is_added_to_pom() {
+        producerGMMPluginConfiguration("", "jar");
+        assertThat(mavenProducerBuild).content().contains(
+                "<modelVersion>4.0.0</modelVersion> <!-- do_not_remove: published-with-gradle-metadata -->");
     }
 
     @Test


### PR DESCRIPTION
If the POM is just the standard project POM, this does not make it worse. It's even a bit simpler, as the modification is directly proposed instead of telling the user what to do in an error.

The real advantage of this change is if the POM is generated by another plugin – in particular the `flatten-maven-plugin`. Then the user does not have to take care of the marker, which we add automatically to the POM that the flatten plugin generated for publishing.