### PR TITLE
Generate metadata file independent of Maven version

### DIFF
--- a/src/main/java/org/gradlex/maven/gmm/GradleModuleMetadataMojo.java
+++ b/src/main/java/org/gradlex/maven/gmm/GradleModuleMetadataMojo.java
@@ -16,7 +16,6 @@
 
 package org.gradlex.maven.gmm;
 
-import org.apache.maven.Maven;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -30,10 +29,8 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.Properties;
 
 /**
  * Goal that generates Gradle Module Metadata.
@@ -83,7 +80,7 @@ public class GradleModuleMetadataMojo extends AbstractMojo {
 
         try (FileWriter fileWriter = new FileWriter(moduleFile)) {
             GradleModuleMetadataWriter.generateTo(
-                    project, getMavenVersion(),
+                    project,
                     platformDependencies,
                     capabilities,
                     removedDependencies,
@@ -107,23 +104,6 @@ public class GradleModuleMetadataMojo extends AbstractMojo {
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private static String getMavenVersion() throws MojoExecutionException {
-        try (InputStream resource = Maven.class.getClassLoader().getResourceAsStream("org/apache/maven/messages/build.properties")) {
-            if (resource == null) {
-                throw new MojoExecutionException("Unable to determine Maven version.");
-            }
-            Properties properties = new Properties();
-            properties.load(resource);
-            String version = properties.getProperty("version");
-            if (version == null) {
-                throw new MojoExecutionException("Unable to determine Maven version.");
-            }
-            return version;
-        } catch (IOException e) {
-            throw new MojoExecutionException("Unable to determine Maven version.", e);
         }
     }
 }

--- a/src/main/java/org/gradlex/maven/gmm/GradleModuleMetadataWriter.java
+++ b/src/main/java/org/gradlex/maven/gmm/GradleModuleMetadataWriter.java
@@ -54,7 +54,7 @@ public class GradleModuleMetadataWriter {
         }
     }
 
-    public static void generateTo(MavenProject project, String mavenVersion,
+    public static void generateTo(MavenProject project,
                                   List<Dependency> platformDependencies, List<Capability> capabilities,
                                   List<Dependency> removedDependencies,
                                   List<Dependency> compileOnlyApiDependencies,
@@ -62,7 +62,7 @@ public class GradleModuleMetadataWriter {
         JsonWriter jsonWriter = new JsonWriter(writer);
         jsonWriter.setHtmlSafe(false);
         jsonWriter.setIndent("  ");
-        writeComponentWithVariants(project, mavenVersion, platformDependencies, capabilities, removedDependencies, compileOnlyApiDependencies, jsonWriter);
+        writeComponentWithVariants(project, platformDependencies, capabilities, removedDependencies, compileOnlyApiDependencies, jsonWriter);
         jsonWriter.flush();
         writer.append('\n');
     }
@@ -89,7 +89,7 @@ public class GradleModuleMetadataWriter {
         return attributes;
     }
 
-    private static void writeComponentWithVariants(MavenProject project, String mavenVersion,
+    private static void writeComponentWithVariants(MavenProject project,
                                                    List<Dependency> platformDependencies,
                                                    List<Capability> capabilities,
                                                    List<Dependency> removedDependencies,
@@ -98,7 +98,6 @@ public class GradleModuleMetadataWriter {
         jsonWriter.beginObject();
         writeFormat(jsonWriter);
         writeIdentity(project, jsonWriter);
-        writeCreator(mavenVersion, jsonWriter);
         writeVariants(project, platformDependencies, capabilities, removedDependencies, compileOnlyApiDependencies, jsonWriter);
         jsonWriter.endObject();
     }
@@ -130,17 +129,6 @@ public class GradleModuleMetadataWriter {
         writeVariant(project, Variant.API_ELEMENTS, platformDependencies, capabilities, removedDependencies, compileOnlyApiDependencies, jsonWriter);
         writeVariant(project, Variant.RUNTIME_ELEMENTS, platformDependencies, capabilities, removedDependencies, null, jsonWriter);
         jsonWriter.endArray();
-    }
-
-    private static void writeCreator(String mavenVersion, JsonWriter jsonWriter) throws IOException {
-        jsonWriter.name("createdBy");
-        jsonWriter.beginObject();
-        jsonWriter.name("maven");
-        jsonWriter.beginObject();
-        jsonWriter.name("version");
-        jsonWriter.value(mavenVersion);
-        jsonWriter.endObject();
-        jsonWriter.endObject();
     }
 
     private static void writeFormat(JsonWriter jsonWriter) throws IOException {

--- a/src/test/resources/capabilities/expected-module.json
+++ b/src/test/resources/capabilities/expected-module.json
@@ -8,11 +8,6 @@
       "org.gradle.status": "release"
     }
   },
-  "createdBy": {
-    "maven": {
-      "version": "3.9.10"
-    }
-  },
   "variants": [
     {
       "name": "apiElements",

--- a/src/test/resources/combine-with-shade-plugin/expected-module.json
+++ b/src/test/resources/combine-with-shade-plugin/expected-module.json
@@ -8,11 +8,6 @@
       "org.gradle.status": "release"
     }
   },
-  "createdBy": {
-    "maven": {
-      "version": "3.9.10"
-    }
-  },
   "variants": [
     {
       "name": "apiElements",

--- a/src/test/resources/combined-features/expected-module.json
+++ b/src/test/resources/combined-features/expected-module.json
@@ -8,11 +8,6 @@
       "org.gradle.status": "release"
     }
   },
-  "createdBy": {
-    "maven": {
-      "version": "3.9.10"
-    }
-  },
   "variants": [
     {
       "name": "apiElements",

--- a/src/test/resources/compile-only-api-dependencies/expected-module.json
+++ b/src/test/resources/compile-only-api-dependencies/expected-module.json
@@ -8,11 +8,6 @@
       "org.gradle.status": "release"
     }
   },
-  "createdBy": {
-    "maven": {
-      "version": "3.9.10"
-    }
-  },
   "variants": [
     {
       "name": "apiElements",

--- a/src/test/resources/optional-dependencies/expected-module.json
+++ b/src/test/resources/optional-dependencies/expected-module.json
@@ -8,11 +8,6 @@
       "org.gradle.status": "release"
     }
   },
-  "createdBy": {
-    "maven": {
-      "version": "3.9.10"
-    }
-  },
   "variants": [
     {
       "name": "apiElements",

--- a/src/test/resources/parent-dependencies/expected-module.json
+++ b/src/test/resources/parent-dependencies/expected-module.json
@@ -8,11 +8,6 @@
       "org.gradle.status": "release"
     }
   },
-  "createdBy": {
-    "maven": {
-      "version": "3.9.10"
-    }
-  },
   "variants": [
     {
       "name": "apiElements",

--- a/src/test/resources/platform-dependencies/expected-module.json
+++ b/src/test/resources/platform-dependencies/expected-module.json
@@ -8,11 +8,6 @@
       "org.gradle.status": "release"
     }
   },
-  "createdBy": {
-    "maven": {
-      "version": "3.9.10"
-    }
-  },
   "variants": [
     {
       "name": "apiElements",

--- a/src/test/resources/snapshot-status-attribute/expected-module.json
+++ b/src/test/resources/snapshot-status-attribute/expected-module.json
@@ -8,11 +8,6 @@
       "org.gradle.status": "integration"
     }
   },
-  "createdBy": {
-    "maven": {
-      "version": "3.9.10"
-    }
-  },
   "variants": [
     {
       "name": "apiElements",

--- a/src/test/resources/variant-dependencies/expected-module.json
+++ b/src/test/resources/variant-dependencies/expected-module.json
@@ -8,11 +8,6 @@
       "org.gradle.status": "release"
     }
   },
-  "createdBy": {
-    "maven": {
-      "version": "3.9.10"
-    }
-  },
   "variants": [
     {
       "name": "apiElements",


### PR DESCRIPTION
Resolves #43

This removes the `createdBy` section completely from the metadata files.

It is not used by Gradle anyway. It is simply skipped [here](https://github.com/gradle/gradle/blob/9513aae9c3d3ee09304e2018f236683fd4f54b13/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java#L162-L161).
The specification also [states that it is optional](https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md#contents).

This also allows us to remove the bit of code that determines the current Maven version from this plugin.